### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/contrib/svn-gource.py
+++ b/contrib/svn-gource.py
@@ -69,7 +69,7 @@ def processXmltree(xmltree):
                 continue;
 
             # join output
-            print( "|".join( ( "%d" % int(timestamp), "%s" % author.encode("utf-8"), "%s" % pathentry.get("action"), "%s" % pathentry.text.encode("utf-8"), "" ) ) )
+            print( "|".join( ( "{0:d}".format(int(timestamp)), "{0!s}".format(author.encode("utf-8")), "{0!s}".format(pathentry.get("action")), "{0!s}".format(pathentry.text.encode("utf-8")), "" ) ) )
 
 def printUsage(message):
     sys.stderr.write(_USAGE)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:tabuu9:Gource?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:tabuu9:Gource?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
